### PR TITLE
feat: configurable polling timeout (MAX_ATTEMPTS / POLL_INTERVAL_SECONDS)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,3 +19,11 @@ inputs:
     VERIFY_JOB: 
      description: 'Wait for dispatch to complete, off by default, set to true to wait for the job to complete'
      required: false
+    MAX_ATTEMPTS:
+     description: 'Maximum number of polling attempts before giving up (only used when VERIFY_JOB is true). Defaults to 16. Effective timeout = MAX_ATTEMPTS x POLL_INTERVAL_SECONDS.'
+     required: false
+     default: '16'
+    POLL_INTERVAL_SECONDS:
+     description: 'Seconds to wait between polling attempts (only used when VERIFY_JOB is true). Defaults to 30.'
+     required: false
+     default: '30'

--- a/dist/index.js
+++ b/dist/index.js
@@ -28865,15 +28865,17 @@ function checkWorkflowStatus(octokit, owner, repo, workflowName, current_time, t
         }
     });
 }
-function waitForWorkflowCompletion(octokit, owner, repo, workflowName) {
+function waitForWorkflowCompletion(octokit, owner, repo, workflowName, maxAttempts, pollIntervalSeconds) {
     return __awaiter(this, void 0, void 0, function* () {
-        const MAX_ATTEMPTS = 16;
         let attempt = 0;
         const current_time = new Date();
         core.info('Current Time: ' + current_time.toISOString());
         const thirtySecsLater = new Date(current_time.getTime() + 30000);
+        const pollIntervalMs = pollIntervalSeconds * 1000;
+        core.info(`Polling up to ${maxAttempts} attempt(s) every ${pollIntervalSeconds}s ` +
+            `(~${Math.round((maxAttempts * pollIntervalSeconds) / 60)} min max).`);
         let res = { status: null, conclusion: null };
-        while (attempt < MAX_ATTEMPTS) {
+        while (attempt < maxAttempts) {
             res = yield checkWorkflowStatus(octokit, owner, repo, workflowName, current_time, thirtySecsLater);
             if (res && res.status === 'completed') {
                 if (res.conclusion === 'success') {
@@ -28893,14 +28895,31 @@ function waitForWorkflowCompletion(octokit, owner, repo, workflowName) {
             }
             attempt++;
             core.info('Attempt: ' + attempt);
-            yield new Promise((resolve) => setTimeout(resolve, 30000)); // 30 seconds
+            yield new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
         }
-        if (attempt === MAX_ATTEMPTS) {
+        if (attempt === maxAttempts) {
             core.error('Max attempts reached without completion. Exiting.');
             process.exit(1);
         }
     });
 }
+// Parse a positive-integer input, falling back to a default for empty or
+// invalid values so callers can omit it and preserve historical behavior.
+function parsePositiveInt(value, fallback) {
+    if (!value) {
+        return fallback;
+    }
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        core.warning(`Invalid positive integer input "${value}"; falling back to ${fallback}.`);
+        return fallback;
+    }
+    return parsed;
+}
+// Defaults preserve the historical ~8 minute ceiling (16 attempts x 30s) so
+// existing consumers that don't set these inputs are unaffected.
+const DEFAULT_MAX_ATTEMPTS = 16;
+const DEFAULT_POLL_INTERVAL_SECONDS = 30;
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         const githubToken = core.getInput('GITHUB_TOKEN');
@@ -28909,6 +28928,8 @@ function run() {
         const clientPayload = core.getInput('CLIENT_PAYLOAD', { required: false });
         const verifyJobInput = core.getInput('VERIFY_JOB');
         const verifyJob = verifyJobInput.toLowerCase() === 'true';
+        const maxAttempts = parsePositiveInt(core.getInput('MAX_ATTEMPTS'), DEFAULT_MAX_ATTEMPTS);
+        const pollIntervalSeconds = parsePositiveInt(core.getInput('POLL_INTERVAL_SECONDS'), DEFAULT_POLL_INTERVAL_SECONDS);
         // Create a new Octokit instance
         const octokit = new rest_1.Octokit({
             auth: githubToken,
@@ -28919,7 +28940,7 @@ function run() {
         yield dispatchWorkflowEvent(octokit, owner, repo, workflowName, clientPayload);
         // Only wait for workflow completion if VERIFY_JOB is true
         if (verifyJob) {
-            yield waitForWorkflowCompletion(octokit, owner, repo, workflowName);
+            yield waitForWorkflowCompletion(octokit, owner, repo, workflowName, maxAttempts, pollIntervalSeconds);
         }
         else {
             core.info(`VERIFY_JOB is not enabled. ${workflowName} was dispatched from ${repo}.`);

--- a/index.ts
+++ b/index.ts
@@ -66,15 +66,27 @@ async function checkWorkflowStatus(octokit: Octokit, owner: string, repo: string
     }
 }
 
-async function waitForWorkflowCompletion(octokit: Octokit, owner: string, repo: string, workflowName: string) {
-    const MAX_ATTEMPTS = 16;
+async function waitForWorkflowCompletion(
+    octokit: Octokit,
+    owner: string,
+    repo: string,
+    workflowName: string,
+    maxAttempts: number,
+    pollIntervalSeconds: number
+) {
     let attempt = 0;
     const current_time = new Date();
     core.info('Current Time: ' + current_time.toISOString());
     const thirtySecsLater = new Date(current_time.getTime() + 30000);
+    const pollIntervalMs = pollIntervalSeconds * 1000;
+
+    core.info(
+        `Polling up to ${maxAttempts} attempt(s) every ${pollIntervalSeconds}s ` +
+        `(~${Math.round((maxAttempts * pollIntervalSeconds) / 60)} min max).`
+    );
 
     let res: WorkflowRunStatus = { status: null, conclusion: null };
-    while (attempt < MAX_ATTEMPTS) {
+    while (attempt < maxAttempts) {
         res = await checkWorkflowStatus(octokit, owner, repo, workflowName, current_time, thirtySecsLater);
         if (res && res.status === 'completed') {
             if (res.conclusion === 'success') {
@@ -91,14 +103,33 @@ async function waitForWorkflowCompletion(octokit: Octokit, owner: string, repo: 
         }
         attempt++;
         core.info('Attempt: ' + attempt);
-        await new Promise((resolve) => setTimeout(resolve, 30000)); // 30 seconds
+        await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
     }
 
-    if (attempt === MAX_ATTEMPTS) {
+    if (attempt === maxAttempts) {
         core.error('Max attempts reached without completion. Exiting.');
         process.exit(1);
     }
 }
+
+// Parse a positive-integer input, falling back to a default for empty or
+// invalid values so callers can omit it and preserve historical behavior.
+function parsePositiveInt(value: string, fallback: number): number {
+    if (!value) {
+        return fallback;
+    }
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        core.warning(`Invalid positive integer input "${value}"; falling back to ${fallback}.`);
+        return fallback;
+    }
+    return parsed;
+}
+
+// Defaults preserve the historical ~8 minute ceiling (16 attempts x 30s) so
+// existing consumers that don't set these inputs are unaffected.
+const DEFAULT_MAX_ATTEMPTS = 16;
+const DEFAULT_POLL_INTERVAL_SECONDS = 30;
 
 async function run() {
     const githubToken = core.getInput('GITHUB_TOKEN');
@@ -107,6 +138,11 @@ async function run() {
     const clientPayload = core.getInput('CLIENT_PAYLOAD', { required: false });
     const verifyJobInput = core.getInput('VERIFY_JOB');
     const verifyJob = verifyJobInput.toLowerCase() === 'true';
+    const maxAttempts = parsePositiveInt(core.getInput('MAX_ATTEMPTS'), DEFAULT_MAX_ATTEMPTS);
+    const pollIntervalSeconds = parsePositiveInt(
+        core.getInput('POLL_INTERVAL_SECONDS'),
+        DEFAULT_POLL_INTERVAL_SECONDS
+    );
 
     // Create a new Octokit instance
     const octokit = new Octokit({
@@ -121,7 +157,7 @@ async function run() {
 
     // Only wait for workflow completion if VERIFY_JOB is true
     if (verifyJob) {
-        await waitForWorkflowCompletion(octokit, owner, repo, workflowName);
+        await waitForWorkflowCompletion(octokit, owner, repo, workflowName, maxAttempts, pollIntervalSeconds);
     } else {
         core.info(`VERIFY_JOB is not enabled. ${workflowName} was dispatched from ${repo}.`);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wait-for-workflow",
-  "version": "1.0.10",
+  "version": "1.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wait-for-workflow",
-      "version": "1.0.10",
+      "version": "1.0.13",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.10.1",
@@ -14,6 +14,7 @@
         "@octokit/rest": "^20.0.2"
       },
       "devDependencies": {
+        "@types/node": "^20.19.41",
         "@vercel/ncc": "^0.38.1",
         "husky": "^8.0.3",
         "typescript": "^5.3.3"
@@ -199,6 +200,16 @@
         "@octokit/openapi-types": "^19.1.0"
       }
     },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/@vercel/ncc": {
       "version": "0.38.1",
       "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.1.tgz",
@@ -272,6 +283,13 @@
       "engines": {
         "node": ">=14.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wait-for-workflow",
-  "version": "1.0.11",
+  "version": "1.0.13",
   "description": "wait for a workflow dispatch result",
   "main": "index.ts",
   "scripts": {
@@ -15,6 +15,7 @@
     "@octokit/rest": "^20.0.2"
   },
   "devDependencies": {
+    "@types/node": "^20.19.41",
     "@vercel/ncc": "^0.38.1",
     "husky": "^8.0.3",
     "typescript": "^5.3.3"


### PR DESCRIPTION
## Summary

The wait loop in `waitForWorkflowCompletion` was hardcoded to **16 attempts × 30s ≈ 8 minutes**. Workflows that legitimately run longer (e.g. the learn-webapp Cypress E2E suites, which include setup + parallel specs + a results-aggregation job) exceed that ceiling, so the action exits with `Max attempts reached without completion` and the caller reports a **false failure** even though the target run ultimately passes.

This makes the timeout configurable instead.

## Changes

- Add two **optional** inputs:
  - `MAX_ATTEMPTS` (default `16`)
  - `POLL_INTERVAL_SECONDS` (default `30`)
- Parameterize the polling loop with them. Effective timeout = `MAX_ATTEMPTS × POLL_INTERVAL_SECONDS`.
- Inputs are parsed defensively (`parsePositiveInt`): empty or invalid values fall back to the defaults with a warning.
- Add `@types/node` as a `devDependency` so the `ncc` build of `dist/index.js` is reproducible.
- Rebuilt `dist/index.js` (also auto-rebuilt by the husky pre-commit hook).

## Backwards compatibility

**Defaults are unchanged**, so any existing consumer that omits these inputs keeps the historical ~8-minute behavior. Only callers that opt in get a longer window. No other behavior changes.

## Follow-up

Once this is merged and tagged (e.g. `v1.0.13`), `adept-at/learn-webapp` will bump its pin from `@v1.0.12` → `@v1.0.13` and pass `MAX_ATTEMPTS: '40'` (~20 min) in `.github/actions/dispatch-test-with-wait`, so the wait covers the full Cypress duration. This is the upstream root-cause fix for the false "❌ tests failed" comments addressed defensively in adept-at/learn-webapp#3688.

## Test plan

- [ ] Existing consumers (no new inputs) behave exactly as before — 16 × 30s.
- [ ] A consumer passing `MAX_ATTEMPTS: '40'` polls for ~20 min before timing out.
- [ ] Invalid input (e.g. `0`, `abc`) logs a warning and falls back to the default.
